### PR TITLE
Improve test coverage

### DIFF
--- a/pkg/kube_utils/kube_utils_test.go
+++ b/pkg/kube_utils/kube_utils_test.go
@@ -188,8 +188,9 @@ func TestKubeControllersGetNode(t *testing.T) {
 
 func TestKubeControllersGetConfigMap(t *testing.T) {
 	type testConfigMap struct {
-		name      string
-		namespace string
+		name        string
+		namespace   string
+		labelPrefix string
 	}
 	testCases := []struct {
 		name              string
@@ -199,9 +200,9 @@ func TestKubeControllersGetConfigMap(t *testing.T) {
 	}{
 		{
 			name:  "When correct ConfigMap is obtained as expected",
-			cmkey: "cdi-dra-dds/test-configmap-1",
+			cmkey: "cdi-dra-dds/test-configmap-0",
 			expectedConfigMap: testConfigMap{
-				name:      "test-configmap-1",
+				name:      "test-configmap-0",
 				namespace: "cdi-dra-dds",
 			},
 			expectedErr: false,
@@ -245,6 +246,12 @@ func TestKubeControllersGetConfigMap(t *testing.T) {
 			if cm != nil {
 				if cm.Name != tc.expectedConfigMap.name {
 					t.Errorf("expected %q, got %q", tc.expectedConfigMap.name, cm.Name)
+				}
+				if cm.Namespace != tc.expectedConfigMap.namespace {
+					t.Errorf("expected %q, got %q", tc.expectedConfigMap.namespace, cm.Namespace)
+				}
+				if cm.Data[config.LabelPrefixKey] != tc.expectedConfigMap.labelPrefix {
+					t.Errorf("expected %q, got %q", tc.expectedConfigMap.labelPrefix, cm.Data[config.LabelPrefixKey])
 				}
 			}
 		})

--- a/pkg/kube_utils/kube_utils_test.go
+++ b/pkg/kube_utils/kube_utils_test.go
@@ -164,8 +164,8 @@ func TestKubeControllersGetNode(t *testing.T) {
 			}
 
 			kubeclient, dynamicclient := CreateTestClient(t, testConfig)
-			controllers, stop := CreateTestKubeControllers(t, testConfig, kubeclient, dynamicclient)
-			defer stop()
+			controllers, stopController := CreateTestKubeControllers(t, testConfig, kubeclient, dynamicclient)
+			defer stopController()
 
 			node, err := controllers.GetNode(tc.nodeName)
 			if tc.expectedErr {
@@ -228,8 +228,8 @@ func TestKubeControllersGetConfigMap(t *testing.T) {
 	}
 
 	kubeclient, dynamicclient := CreateTestClient(t, testConfig)
-	controllers, stop := CreateTestKubeControllers(t, testConfig, kubeclient, dynamicclient)
-	defer stop()
+	controllers, stopController := CreateTestKubeControllers(t, testConfig, kubeclient, dynamicclient)
+	defer stopController()
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -301,8 +301,8 @@ func TestKubeControllersGetSecret(t *testing.T) {
 				Secret: secret,
 			}
 			kubeclient, dynamicclient := CreateTestClient(t, testConfig)
-			controllers, stop := CreateTestKubeControllers(t, testConfig, kubeclient, dynamicclient)
-			defer stop()
+			controllers, stopController := CreateTestKubeControllers(t, testConfig, kubeclient, dynamicclient)
+			defer stopController()
 			secret, err := controllers.GetSecret("composable-dra/composable-dra-secret")
 			if tc.expectedErr {
 				if err == nil {
@@ -375,8 +375,8 @@ func TestKubeControllersListProviderIDs(t *testing.T) {
 			}
 
 			kubeclient, dynamicclient := CreateTestClient(t, testConfig)
-			controllers, stop := CreateTestKubeControllers(t, testConfig, kubeclient, dynamicclient)
-			defer stop()
+			controllers, stopController := CreateTestKubeControllers(t, testConfig, kubeclient, dynamicclient)
+			defer stopController()
 
 			providerIDs, err := controllers.ListProviderIDs()
 			if tc.expectedErr {
@@ -435,8 +435,8 @@ func TestKubeControllersFindNodeNameByProviderID(t *testing.T) {
 			}
 
 			kubeclient, dynamicclient := CreateTestClient(t, testConfig)
-			controllers, stop := CreateTestKubeControllers(t, testConfig, kubeclient, dynamicclient)
-			defer stop()
+			controllers, stopController := CreateTestKubeControllers(t, testConfig, kubeclient, dynamicclient)
+			defer stopController()
 
 			nodeName, err := controllers.FindNodeNameByProviderID(normalizedProviderID(tc.providerID))
 			if tc.expectedErr {
@@ -487,8 +487,8 @@ func TestKubeControllersFindMachineUUIDByProviderID(t *testing.T) {
 			}
 
 			kubeclient, dynamicclient := CreateTestClient(t, testConfig)
-			controllers, stop := CreateTestKubeControllers(t, testConfig, kubeclient, dynamicclient)
-			defer stop()
+			controllers, stopController := CreateTestKubeControllers(t, testConfig, kubeclient, dynamicclient)
+			defer stopController()
 
 			muuid, err := controllers.FindMachineUUIDByProviderID(normalizedProviderString(tc.providerID))
 			if tc.expectedErr {

--- a/pkg/kube_utils/kube_utils_test.go
+++ b/pkg/kube_utils/kube_utils_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -387,6 +388,17 @@ func TestKubeControllersListProviderIDs(t *testing.T) {
 			for i := 0; i < tc.nodeCount; i++ {
 				testConfig.Nodes[i], testConfig.BMHs[i] = CreateNodeBMHs(i, "test-namespace", tc.useCapiBmh)
 			}
+
+			// Add node without provider id
+			node := &corev1.Node{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "Node",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node-has-no-provider-id",
+				},
+			}
+			testConfig.Nodes = append(testConfig.Nodes, node)
 
 			kubeclient, dynamicclient := CreateTestClient(t, testConfig)
 			controllers, stopController := CreateTestKubeControllers(t, testConfig, kubeclient, dynamicclient)

--- a/pkg/kube_utils/kube_utils_test.go
+++ b/pkg/kube_utils/kube_utils_test.go
@@ -438,10 +438,10 @@ func TestKubeControllersFindNodeNameByProviderID(t *testing.T) {
 			expectedNodeName: "test-node-1",
 		},
 		{
-			name:             "When non-exist provider ID is specified",
+			name:             "When non-existent provider ID is specified",
 			nodeCount:        1,
 			useCapiBmh:       false,
-			providerID:       "non-exist-provider-id",
+			providerID:       "non-existent-provider-id",
 			expectedErr:      false,
 			expectedNodeName: "",
 		},
@@ -491,6 +491,13 @@ func TestKubeControllersFindMachineUUIDByProviderID(t *testing.T) {
 			providerID:          "00000000-0000-0000-0000-000000000000",
 			expectedErr:         false,
 			expectedMachineUUID: "00000000-0000-0000-0000-000000000000",
+		},
+		{
+			name:                "When non-existent provider id is specified",
+			nodeCount:           1,
+			providerID:          "non-existent-provider-id",
+			expectedErr:         false,
+			expectedMachineUUID: "",
 		},
 	}
 

--- a/pkg/kube_utils/kube_utils_test.go
+++ b/pkg/kube_utils/kube_utils_test.go
@@ -437,6 +437,14 @@ func TestKubeControllersFindNodeNameByProviderID(t *testing.T) {
 			expectedErr:      false,
 			expectedNodeName: "test-node-1",
 		},
+		{
+			name:             "When non-exist provider ID is specified",
+			nodeCount:        1,
+			useCapiBmh:       false,
+			providerID:       "non-exist-provider-id",
+			expectedErr:      false,
+			expectedNodeName: "",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This pull request enhances the overall test coverage of utility functions and edge-case behaviors in the kube_utils. Key changes include:
- Added test cases for FindMachineUUIDByProviderID covering scenarios with missing UUID, missing annotations, and non-existent provider IDs
- Added test for FindNodeNameByProviderID with non-existent provider ID
- Improved test coverage for ListProviderIDs when nodes lack provider IDs
- Added tests for groupVersionHasResource behavior
- Improved unit tests for retrieving Secrets and ConfigMaps in kube_utils
