### PR TITLE
Refactor ResourceSlice management and when a node doesn't belong node group

### DIFF
--- a/pkg/client/test_helper.go
+++ b/pkg/client/test_helper.go
@@ -674,7 +674,7 @@ func BuildTestClientSet(t testing.TB, testSpec config.TestSpec) (TestClientSet, 
 		BMHs:   make([]*unstructured.Unstructured, config.TestNodeCount),
 	}
 	for i := 0; i < config.TestNodeCount; i++ {
-		testConfig.Nodes[i], testConfig.BMHs[i] = ku.CreateNodeBMHs(i, "test-namespace", testConfig.Spec.UseCapiBmh)
+		testConfig.Nodes[i], testConfig.BMHs[i] = ku.CreateNodeBMHs(i, "test-namespace", testSpec.UseCapiBmh)
 	}
 
 	kubeclient, dynamicclient := ku.CreateTestClient(t, testConfig)

--- a/pkg/client/test_helper.go
+++ b/pkg/client/test_helper.go
@@ -563,16 +563,18 @@ func handleRequests(w http.ResponseWriter, r *http.Request) {
 						remainder = strings.TrimPrefix(remainder, tenantID2+"/clusters")
 						tenantId = tenantID2
 					}
-					muuid := strings.TrimPrefix(remainder, "/"+clusterID1+"/machines/")
-					r := regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$")
-					if r.MatchString(muuid) {
-						index, _ := strconv.Atoi(string(muuid[len(muuid)-1]))
-						if tenantId == tenantID1 {
-							written = writeResponse(w, http.StatusOK, testNodeDetails1)
-						}
-						if tenantId == tenantID2 {
-							if index <= len(testNodeDetails2) {
-								written = writeResponse(w, http.StatusOK, testNodeDetails2[index])
+					if len(tenantId) != 0 {
+						muuid := strings.TrimPrefix(remainder, "/"+clusterID1+"/machines/")
+						r := regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$")
+						if r.MatchString(muuid) {
+							index, _ := strconv.Atoi(string(muuid[len(muuid)-1]))
+							if tenantId == tenantID1 {
+								written = writeResponse(w, http.StatusOK, testNodeDetails1)
+							}
+							if tenantId == tenantID2 {
+								if index <= len(testNodeDetails2) {
+									written = writeResponse(w, http.StatusOK, testNodeDetails2[index])
+								}
 							}
 						}
 					}

--- a/pkg/client/test_helper.go
+++ b/pkg/client/test_helper.go
@@ -515,6 +515,14 @@ func handleRequests(w http.ResponseWriter, r *http.Request) {
 									written = writeResponse(w, http.StatusOK, testNodeGroups2)
 								}
 							}
+							if !written {
+								unSuccess := unsuccessfulResponse{
+									Detail: responseDetail{
+										Message: "CM node group list API is failed",
+									},
+								}
+								writeResponse(w, http.StatusNotFound, unSuccess)
+							}
 						} else {
 							ngId := strings.TrimPrefix(remainder, "/"+clusterID1+"/nodegroups")
 							if tenantId == tenantID1 {
@@ -533,17 +541,16 @@ func handleRequests(w http.ResponseWriter, r *http.Request) {
 									written = writeResponse(w, http.StatusOK, testNodeGroupInfos2[2])
 								}
 							}
+							if !written {
+								unSuccess := unsuccessfulResponse{
+									Detail: responseDetail{
+										Message: "CM node group info API is failed",
+									},
+								}
+								writeResponse(w, http.StatusNotFound, unSuccess)
+							}
 						}
 					}
-					if !written {
-						unSuccess := unsuccessfulResponse{
-							Detail: responseDetail{
-								Message: "CM node group list API is failed",
-							},
-						}
-						writeResponse(w, http.StatusNotFound, unSuccess)
-					}
-
 				}
 				if strings.HasPrefix(remainder, "/v3/tenants/") {
 					remainder = strings.TrimPrefix(remainder, "/v3/tenants/")

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -493,8 +493,9 @@ func (m *CDIManager) manageCDIResourceSlices(machines []*machine, controlles map
 			for _, device := range machine.deviceList {
 				if _, exist := m.namedDriverResources[device.driverName]; exist {
 					poolName := device.k8sDeviceName + "-fabric" + strconv.Itoa(*machine.fabricID)
-					updated := m.updatePool(device.driverName, poolName, device, *machine.fabricID)
+					updated := m.updatePool(poolName, device, *machine.fabricID)
 					if updated {
+						slog.Info("pool update", "poolName", poolName, "generation", m.namedDriverResources[device.driverName].Pools[poolName].Generation, "driver", device.driverName)
 						needUpdate[device.driverName] = true
 					}
 				}
@@ -505,25 +506,22 @@ func (m *CDIManager) manageCDIResourceSlices(machines []*machine, controlles map
 	for driverName, driverResources := range m.namedDriverResources {
 		if needUpdate[driverName] {
 			c := controlles[driverName]
-			for poolName := range driverResources.Pools {
-				slog.Info("pool update", "poolName", poolName, "generation", m.namedDriverResources[driverName].Pools[poolName].Generation, "driver", driverName)
-			}
 			c.Update(driverResources)
 		}
 	}
 }
 
-func (m *CDIManager) updatePool(driverName string, poolName string, device *device, fabricID int) (updated bool) {
+func (m *CDIManager) updatePool(poolName string, device *device, fabricID int) (updated bool) {
 	var generation int64 = 1
-	pool := m.namedDriverResources[driverName].Pools[poolName]
+	pool := m.namedDriverResources[device.driverName].Pools[poolName]
 	if len(pool.Slices) == 0 {
-		m.namedDriverResources[driverName].Pools[poolName] = m.generatePool(device, fabricID, generation)
+		m.namedDriverResources[device.driverName].Pools[poolName] = m.generatePool(device, fabricID, generation)
 		return true
 	} else {
 		if len(pool.Slices[0].Devices) != device.availableDeviceCount {
 			generation = pool.Generation
 			generation++
-			m.namedDriverResources[driverName].Pools[poolName] = m.generatePool(device, fabricID, generation)
+			m.namedDriverResources[device.driverName].Pools[poolName] = m.generatePool(device, fabricID, generation)
 			return true
 		}
 	}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -307,6 +307,9 @@ func (m *CDIManager) startCheckResourcePoolLoop(ctx context.Context, controllers
 		type deviceMinMax map[string]limit
 		nodeGroupFound := make(map[string]deviceMinMax)
 		for _, machine := range machines {
+			if len(machine.nodeGroupUUID) == 0 {
+				continue
+			}
 			if _, exists := nodeGroupFound[machine.nodeGroupUUID]; exists {
 				continue
 			}

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -814,7 +814,7 @@ func TestCDIManagerGetAvailableNums(t *testing.T) {
 				if err == nil {
 					t.Error("expected error, but got none")
 				}
-				if !strings.Contains(err.Error(), tc.expectedErrMsg) {
+				if err != nil && !strings.Contains(err.Error(), tc.expectedErrMsg) {
 					t.Errorf("unexpected error message, expected %s but got %s", tc.expectedErrMsg, err.Error())
 				}
 			} else if !tc.expectedErr {
@@ -832,7 +832,9 @@ func TestCDIManagerGetAvailableNums(t *testing.T) {
 func TestCDIManagerGetNodeGroups(t *testing.T) {
 	testCases := []struct {
 		name                    string
+		tenantId                string
 		expectedErr             bool
+		expectedErrMsg          string
 		expectedNodeGroupLength int
 	}{
 		{
@@ -840,11 +842,18 @@ func TestCDIManagerGetNodeGroups(t *testing.T) {
 			expectedErr:             false,
 			expectedNodeGroupLength: 3,
 		},
+		{
+			name:           "When node groups API is failed",
+			tenantId:       "00000000-0000-0404-0000-000000000000",
+			expectedErr:    true,
+			expectedErrMsg: "CM node groups API failed",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			testSpec := config.TestSpec{
 				DRAenabled: true,
+				TenantID:   tc.tenantId,
 			}
 			m, server, stop := createTestManager(t, testSpec)
 			defer stop()
@@ -854,6 +863,9 @@ func TestCDIManagerGetNodeGroups(t *testing.T) {
 			if tc.expectedErr {
 				if err == nil {
 					t.Error("expected error, but got none")
+				}
+				if err != nil && !strings.Contains(err.Error(), tc.expectedErrMsg) {
+					t.Errorf("unexpected error message, expected %s but got %s", tc.expectedErrMsg, err.Error())
 				}
 			} else if !tc.expectedErr {
 				if err != nil {

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -31,7 +31,6 @@ import (
 	"testing"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1117,11 +1116,11 @@ func TestCDIManagerManageCDIResourceSlices(t *testing.T) {
 							for _, nodeSelector := range nodeSelectors.MatchExpressions {
 								switch nodeSelector.Key {
 								case "cohdi.com/" + tc.expectedDeviceName:
-									if nodeSelector.Operator != corev1.NodeSelectorOpIn || !slices.Contains(nodeSelector.Values, "true") {
+									if nodeSelector.Operator != v1.NodeSelectorOpIn || !slices.Contains(nodeSelector.Values, "true") {
 										t.Errorf("unexpected nodeSelector is set in device key field")
 									}
 								case "cohdi.com/fabric":
-									if nodeSelector.Operator != corev1.NodeSelectorOpIn || !slices.Contains(nodeSelector.Values, "1") {
+									if nodeSelector.Operator != v1.NodeSelectorOpIn || !slices.Contains(nodeSelector.Values, "1") {
 										t.Errorf("unexpected nodeSelector is set in fabric key field")
 									}
 								default:
@@ -1196,7 +1195,7 @@ func TestCDIManagerUpdatePool(t *testing.T) {
 				poolName := device.k8sDeviceName + "-fabric" + strconv.Itoa(tc.fabricID)
 				var updated bool
 				if _, exist := m.namedDriverResources[device.driverName]; exist {
-					updated = m.updatePool(device.driverName, poolName, device, tc.fabricID)
+					updated = m.updatePool(poolName, device, tc.fabricID)
 				}
 				if tc.expectedUpdated {
 					if !updated {

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -952,8 +952,8 @@ func TestCDIManagerGetMinMaxNums(t *testing.T) {
 		modelName      string
 		expectedErr    bool
 		expectedErrMsg string
-		expectedMin    int
-		expectedMax    int
+		expectedMin    *int
+		expectedMax    *int
 	}{
 		{
 			name:        "When correct min/max number of fabric devices is obtained as expected",
@@ -961,8 +961,8 @@ func TestCDIManagerGetMinMaxNums(t *testing.T) {
 			machineUUID: "00000000-0000-0000-0000-000000000000",
 			modelName:   "DEVICE 1",
 			expectedErr: false,
-			expectedMin: 1,
-			expectedMax: 3,
+			expectedMin: ptr.To(1),
+			expectedMax: ptr.To(3),
 		},
 		{
 			name:           "When node details API is failed",
@@ -971,6 +971,15 @@ func TestCDIManagerGetMinMaxNums(t *testing.T) {
 			modelName:      "DEVICE 1",
 			expectedErr:    true,
 			expectedErrMsg: "CM node details API failed",
+		},
+		{
+			name:        "When not-existsted device model is specified",
+			tenantId:    "00000000-0000-0002-0000-000000000000",
+			machineUUID: "00000000-0000-0000-0000-000000000000",
+			modelName:   "DUMMY DEVICE",
+			expectedErr: false,
+			expectedMin: nil,
+			expectedMax: nil,
 		},
 	}
 	for _, tc := range testCases {
@@ -997,13 +1006,21 @@ func TestCDIManagerGetMinMaxNums(t *testing.T) {
 					t.Errorf("unexpected error: %v", err)
 				}
 				if min != nil {
-					if *min != tc.expectedMin {
-						t.Errorf("unexpected min value, expected %d but got %d", tc.expectedMin, *min)
+					if tc.expectedMin != nil {
+						if *min != *tc.expectedMin {
+							t.Errorf("unexpected min value, expected %d but got %d", *tc.expectedMin, *min)
+						}
+					} else {
+						t.Errorf("unexpected min value, expected min is nil but got not nil")
 					}
 				}
 				if max != nil {
-					if *max != tc.expectedMax {
-						t.Errorf("unexpected max value, expected %d but got %d", tc.expectedMax, *max)
+					if tc.expectedMax != nil {
+						if *max != *tc.expectedMax {
+							t.Errorf("unexpected max value, expected %d but got %d", tc.expectedMax, *max)
+						}
+					} else {
+						t.Errorf("unexpected max value, expected max is nil but got not nil")
 					}
 				}
 			}

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -721,13 +721,21 @@ func TestCDIManagerGetMachineUUID(t *testing.T) {
 func TestCDIManagerGetMachineList(t *testing.T) {
 	testCases := []struct {
 		name              string
+		tenantId          string
 		expectedNodeCount int
 		expectedErr       bool
+		expectedErrMsg    string
 	}{
 		{
 			name:              "When correct machine list is obtained as expected",
 			expectedNodeCount: 9,
 			expectedErr:       false,
+		},
+		{
+			name:           "When machine list API is failed",
+			tenantId:       "00000000-0000-0404-0000-000000000000",
+			expectedErr:    true,
+			expectedErrMsg: "FM machine list API failed",
 		},
 	}
 	for _, tc := range testCases {
@@ -735,6 +743,7 @@ func TestCDIManagerGetMachineList(t *testing.T) {
 			testSpec := config.TestSpec{
 				UseCapiBmh: false,
 				DRAenabled: true,
+				TenantID:   tc.tenantId,
 			}
 			m, server, stop := createTestManager(t, testSpec)
 			defer stop()
@@ -742,7 +751,9 @@ func TestCDIManagerGetMachineList(t *testing.T) {
 
 			mList, err := m.getMachineList(context.Background())
 			if tc.expectedErr {
-
+				if err == nil {
+					t.Errorf("expected error, but got none")
+				}
 			} else if !tc.expectedErr {
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)


### PR DESCRIPTION
This PR includes a series of refactors and test improvements focused on resource slice management and node group handling logic.
### Refactoring Highlights
- Modified the log output to include only the updated pool name.
- Unnecessary function arguments have been removed.
- Skipped unnecessary calls to getMinMaxNums when the node doesn't belong to a node group.

### Test Coverage Improvements
Added anomaly case tests for:
- getMinMaxNums
- getNodeGroupInfo
- getNodeGroups
- getMachineList
- getMachineUUID
- startResourceSliceController (when DRA is disabled)
- manageCDIResourceSlices

