### PR TITLE
fix: set size-min/size-max labels to "0" when CM has no device entry

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -609,7 +609,7 @@ func (m *CDIManager) manageCDINodeLabel(ctx context.Context, machines []*machine
 							slog.Info("set labels for max of devices", "nodeName", machine.nodeName, "label", maxLabelKey+"="+max)
 						}
 					} else {
-						delete(node.Labels, maxLabelKey)
+						node.Labels[maxLabelKey] = "0"
 					}
 					minLabelKey := m.labelPrefix + "/" + device.k8sDeviceName + "-size-min"
 					if device.minDeviceCount != nil {
@@ -619,7 +619,7 @@ func (m *CDIManager) manageCDINodeLabel(ctx context.Context, machines []*machine
 							slog.Info("set labels for min of devices", "nodeName", machine.nodeName, "label", minLabelKey+"="+min)
 						}
 					} else {
-						delete(node.Labels, minLabelKey)
+						node.Labels[minLabelKey] = "0"
 					}
 				}
 			}

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -1429,8 +1429,8 @@ func TestCDIManagerManageCDINodeLabel(t *testing.T) {
 			loopSpecs: []loopSpec{
 				{
 					caseDevice:        CaseDeviceMinMaxNil,
-					expectedMinDevice: "",
-					expectedMaxDevice: "",
+					expectedMinDevice: "0",
+					expectedMaxDevice: "0",
 				},
 			},
 			expectedFabric: "1",
@@ -1457,7 +1457,7 @@ func TestCDIManagerManageCDINodeLabel(t *testing.T) {
 			expectedErr:    false,
 		},
 		{
-			name:       "When label is removed if min and max becomes nil",
+			name:       "When label is updated to 0 if min and max transitions from non-nil to nil",
 			useCM:      true,
 			nodeName:   "test-node-0",
 			deviceName: "test-device-1",
@@ -1469,8 +1469,8 @@ func TestCDIManagerManageCDINodeLabel(t *testing.T) {
 				},
 				{
 					caseDevice:        CaseDeviceMinMaxNil,
-					expectedMinDevice: "",
-					expectedMaxDevice: "",
+					expectedMinDevice: "0",
+					expectedMaxDevice: "0",
 				},
 			},
 			expectedFabric: "1",


### PR DESCRIPTION
## Summary

When a device has no entry in the CM order sheet, the `-size-min` and `-size-max` node labels were deleted. However, a missing label causes DDS to treat the device as unbounded, allowing unlimited GPU attachment unintentionally.

This PR fixes the behavior by setting the labels to `"0"` instead of deleting them when min/max count is unavailable from CM. This correctly signals to DDS that the device is unavailable.

## Changes

- `manager.go`: Set size-min/size-max labels to `"0"` instead of deleting them when min/max is nil
- `manager_test.go`: Update expected values to reflect the new behavior and rename a test case to better describe the non-nil → nil transition scenario

## Background

| Before | After |
|---|---|
| No CM entry → label deleted | No CM entry → label set to `"0"` |
| DDS: treats device as unbounded | DDS: treats device as unavailable |