### PR TITLE
fix: add cleanup of published ResourceSlices on shutdown

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -59,7 +59,7 @@ rules:
   verbs: ["get", "list", "watch", "update", "patch"]
 - apiGroups: ["resource.k8s.io"]
   resources: ["resourceslices"]
-  verbs: ["get", "list", "watch", "create", "patch", "update", "delete", "deletecollection"]
+  verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -59,7 +59,7 @@ rules:
   verbs: ["get", "list", "watch", "update", "patch"]
 - apiGroups: ["resource.k8s.io"]
   resources: ["resourceslices"]
-  verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+  verbs: ["get", "list", "watch", "create", "patch", "update", "delete", "deletecollection"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/main.go
+++ b/main.go
@@ -174,7 +174,13 @@ func newApp() *cli.App {
 
 			select {
 			case s := <-sigs:
-				slog.Info("Signal received", "signal", s.String())
+				slog.Info("Signal received, shutting down", "signal", s.String())
+				// Cancel ctx and wait for StartCDIManager so its deferred cleanup
+				// (stopping controllers, deleting slices) completes before exit.
+				cancel()
+				if err := <-errChan; err != nil {
+					slog.Error("Manager exited with error during shutdown", "error", err)
+				}
 				return nil
 			case err := <-errChan:
 				slog.Error("Failed start manager", "error", err)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
@@ -163,6 +164,8 @@ func StartCDIManager(ctx context.Context, cfg *config.Config) error {
 	if err != nil {
 		return err
 	}
+	// Delete published ResourceSlices on shutdown.
+	defer m.cleanupResourceSlices(controllers)
 
 	wait.Until(func() {
 		slog.Info("Loop Start")
@@ -174,6 +177,34 @@ func StartCDIManager(ctx context.Context, cfg *config.Config) error {
 		}
 	}, cfg.ScanInterval, ctx.Done())
 	return nil
+}
+
+// cleanupResourceSlices stops the ResourceSlice controllers and deletes the
+// slices they published.
+func (m *CDIManager) cleanupResourceSlices(controllers map[string]*resourceslice.Controller) {
+	for driverName, c := range controllers {
+		slog.Info("Stopping ResourceSlice controller", "driverName", driverName)
+		c.Stop()
+	}
+
+	// Parent ctx is already canceled by the time this runs, so use a fresh one.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	for driverName := range controllers {
+		slog.Info("Deleting ResourceSlices published by this driver", "driverName", driverName)
+		err := m.coreClient.ResourceV1().ResourceSlices().DeleteCollection(
+			ctx,
+			metav1.DeleteOptions{},
+			metav1.ListOptions{
+				FieldSelector: "spec.driver=" + driverName,
+			},
+		)
+		if err != nil {
+			slog.Error("Failed to delete ResourceSlices", "driverName", driverName, "error", err)
+			continue
+		}
+	}
 }
 
 func (m *CDIManager) startResourceSliceController(ctx context.Context) (map[string]*resourceslice.Controller, error) {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -193,10 +193,11 @@ func (m *CDIManager) cleanupResourceSlices(controllers map[string]*resourceslice
 	defer cancel()
 
 	for driverName := range controllers {
-		slog.Info("Deleting ResourceSlices published by this driver", "driverName", driverName)
-		err := m.coreClient.ResourceV1().ResourceSlices().DeleteCollection(
+		// List the cluster-wide slices for this driver, then delete only those
+		// whose pool name matches one we published. This guards against deleting
+		// slices from another driver that happens to share the same driver name.
+		list, err := m.coreClient.ResourceV1().ResourceSlices().List(
 			ctx,
-			metav1.DeleteOptions{},
 			metav1.ListOptions{
 				FieldSelector: fields.Set{
 					resourceapi.ResourceSliceSelectorDriver:   driverName,
@@ -205,8 +206,20 @@ func (m *CDIManager) cleanupResourceSlices(controllers map[string]*resourceslice
 			},
 		)
 		if err != nil {
-			slog.Error("Failed to delete ResourceSlices", "driverName", driverName, "error", err)
+			slog.Error("Failed to list ResourceSlices", "driverName", driverName, "error", err)
 			continue
+		}
+
+		publishedPools := m.namedDriverResources[driverName].Pools
+		for i := range list.Items {
+			s := &list.Items[i]
+			if _, ours := publishedPools[s.Spec.Pool.Name]; !ours {
+				continue
+			}
+			slog.Info("Deleting ResourceSlice", "name", s.Name, "driverName", driverName, "pool", s.Spec.Pool.Name)
+			if err := m.coreClient.ResourceV1().ResourceSlices().Delete(ctx, s.Name, metav1.DeleteOptions{}); err != nil {
+				slog.Error("Failed to delete ResourceSlice", "name", s.Name, "error", err)
+			}
 		}
 	}
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
@@ -197,7 +198,10 @@ func (m *CDIManager) cleanupResourceSlices(controllers map[string]*resourceslice
 			ctx,
 			metav1.DeleteOptions{},
 			metav1.ListOptions{
-				FieldSelector: "spec.driver=" + driverName,
+				FieldSelector: fields.Set{
+					resourceapi.ResourceSliceSelectorDriver:   driverName,
+					resourceapi.ResourceSliceSelectorNodeName: "",
+				}.AsSelector().String(),
 			},
 		)
 		if err != nil {


### PR DESCRIPTION
## Summary

Ensure the driver deletes the ResourceSlices it published when it is shut down. Previously, on SIGTERM the driver simply stopped without removing its slices, leaving stale `ResourceSlice` objects in the cluster.

## Motivation

The driver currently leaves the `ResourceSlice` objects it published in the cluster even after it is shut down. This is especially problematic when switching between dynamic scaling (DDS + CDI DRA) and manual scaling (CRO only): leftover slices from CDI DRA interfere with the manual mode, forcing operators to identify and delete those slices by hand.

Reclaiming slices automatically on CDI DRA shutdown removes that manual step and reduces operator burden. It also improves the uninstall experience.

This change targets the **normal shutdown path** (e.g., scaling the Deployment from 1 to 0, or a regular pod termination). Failure-mode shutdowns (crash, OOMKill, node failure, etc.) are out of scope — orphaned slices in those cases are accepted as an acknowledged limitation.

## Changes

- **`pkg/manager/manager.go`**:
  - Add `cleanupResourceSlices` invoked via `defer` in `StartCDIManager`.
  - It calls `Controller.Stop()` for each driver, then lists the cluster-scoped slices for that driver (`FieldSelector: spec.driver=<name>,spec.nodeName=`) and deletes only those whose pool name matches a pool we published. A fresh 30s context is used since the parent context is already canceled at this point.
- **`main.go`**:
  - On SIGTERM, explicitly `cancel()` and then wait on `errChan` so the deferred cleanup in `StartCDIManager` completes before the process exits.
  - Without this, the goroutine and the main routine race and the cleanup may be killed mid-flight.

## Design notes

- `Controller.Stop()` is called explicitly even though ctx cancellation alone would stop the goroutines, because only `Stop()` blocks via `wg.Wait()` and thus prevents a race where an in-flight publish recreates a slice we just deleted.
- Cleanup deletes slices one-by-one after filtering by published pool name, rather than using `DeleteCollection` with `spec.driver=<name>`. This guards against deleting slices owned by another driver that happens to share the same driver name.
